### PR TITLE
Fixes and Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # scMerlin
 
 ## v2.5.40
-### Updated on 2025-July-23
+### Updated on 2025-July-24
 
 ## About
 scMerlin allows you to easily control the most common services/scripts on your router. scMerlin also augments your router's WebUI with a Sitemap and dynamic submenus for the main left menu of Asuswrt-Merlin.

--- a/scmerlin.sh
+++ b/scmerlin.sh
@@ -30,7 +30,7 @@ readonly SCRIPT_NAME="scMerlin"
 readonly SCRIPT_NAME_LOWER="$(echo "$SCRIPT_NAME" | tr 'A-Z' 'a-z' | sed 's/d//')"
 readonly SCM_VERSION="v2.5.40"
 readonly SCRIPT_VERSION="v2.5.40"
-readonly SCRIPT_VERSTAG="25072420"
+readonly SCRIPT_VERSTAG="25072421"
 SCRIPT_BRANCH="develop"
 SCRIPT_REPO="https://raw.githubusercontent.com/AMTM-OSR/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME_LOWER.d"
@@ -3127,7 +3127,7 @@ case "$1" in
 
 			if [ ! -s /tmp/wan_uptime.tmp ]
 			then timeSecs="$(date +%s)"
-			else read ifaceNum timeSecs < /tmp/wan_uptime.tmp
+			else read ifaceNum timeSecs seedTag < /tmp/wan_uptime.tmp
 			fi
 			# Persist start-time #
 			echo "$ifaceNumWAN $timeSecs" > /tmp/wan_uptime.tmp


### PR DESCRIPTION
- Added call to '`NTP_Ready()`' function when the '**connected**' WAN event is detected to make sure the system clock is synced before setting the timestamp in our temporary local file. Otherwise, we get a completely wrong value.

- Minor code improvements.