### PR TITLE
More WAN Uptime Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # scMerlin
 
 ## v2.5.40
-### Updated on 2025-July-25
+### Updated on 2025-July-26
 
 ## About
 scMerlin allows you to easily control the most common services/scripts on your router. scMerlin also augments your router's WebUI with a Sitemap and dynamic submenus for the main left menu of Asuswrt-Merlin.


### PR DESCRIPTION
Modified code to have a separate "SEED" file for each WAN interface so that each would have its own timestamp. In cases where users have 2 WAN interfaces connected (one as the "Active Primary" and the other in "Hot-Standby"), we can keep data for each interface separately.
