### PR TITLE
Code Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # scMerlin
 
-## v2.5.40
-### Updated on 2025-July-26
+## v2.5.41
+### Updated on 2025-Jul-31
 
 ## About
 scMerlin allows you to easily control the most common services/scripts on your router. scMerlin also augments your router's WebUI with a Sitemap and dynamic submenus for the main left menu of Asuswrt-Merlin.


### PR DESCRIPTION
Added code to make sure the script launches the correct time server process (`ntpd` or `chronyd`) when selecting to restart the ntpMerlin-installed time server. This will avoid selecting the wrong service script if more than one is found. This new check requires the installation of **ntpMerlin 3.4.10** or later versions.
