### PR TITLE
Workaround for Entware Binaries using RUNPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # scMerlin
 
-## v2.5.48
-### Updated on 2026-Mar-21
+## v2.5.49
+### Updated on 2026-Apr-11
 
 ## About
 scMerlin allows you to easily control the most common services/scripts on your router. scMerlin also augments your router's WebUI with a Sitemap and dynamic submenus for the main left menu of Asuswrt-Merlin.

--- a/scmerlin.sh
+++ b/scmerlin.sh
@@ -12,7 +12,7 @@
 ## Forked from: https://github.com/jackyaz/scMerlin ##
 ##                                                  ##
 ######################################################
-# Last Modified: 2026-Mar-21
+# Last Modified: 2026-Apr-11
 #-----------------------------------------------------
 
 ##########       Shellcheck directives     ###########
@@ -32,10 +32,10 @@
 ### Start of script variables ###
 readonly SCRIPT_NAME="scMerlin"
 readonly SCRIPT_NAME_LOWER="$(echo "$SCRIPT_NAME" | tr 'A-Z' 'a-z' | sed 's/d//')"
-readonly SCM_VERSION="v2.5.48"
-readonly SCRIPT_VERSION="v2.5.48"
-readonly SCRIPT_VERSTAG="26032101"
-SCRIPT_BRANCH="master"
+readonly SCM_VERSION="v2.5.49"
+readonly SCRIPT_VERSION="v2.5.49"
+readonly SCRIPT_VERSTAG="26041103"
+SCRIPT_BRANCH="develop"
 SCRIPT_REPO="https://raw.githubusercontent.com/AMTM-OSR/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME_LOWER.d"
 readonly SCRIPT_WEBPAGE_DIR="$(readlink -f /www/user)"
@@ -128,6 +128,9 @@ readonly IPv4octet_RegEx="([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])"
 readonly IPv4addrs_RegEx="${IPv4octet_RegEx}([.]$IPv4octet_RegEx){3}"
 
 ### End of output format variables ###
+
+# Workaround for Entware ELF binaries compiled with RUNPATH #
+unset LD_LIBRARY_PATH
 
 # Give priority to built-in binaries #
 export PATH="/bin:/usr/bin:/sbin:/usr/sbin:$PATH"

--- a/tailtaintdns
+++ b/tailtaintdns
@@ -1,13 +1,28 @@
 #!/bin/sh
+######################################################
+# Last Modified: 2026-Apr-11
+#-----------------------------------------------------
 # shellcheck disable=SC2039
 # shellcheck disable=SC3048
+#-----------------------------------------------------
+
 trap '' SIGHUP
+
+# Give priority to built-in binaries #
+export PATH="/bin:/usr/bin:/sbin:/usr/sbin:$PATH"
 
 tailfile="/tmp/syslog.log"
 
 renice 15 $$
-tail -F "$tailfile" | while read -r line; do
-if echo "$line" | grep -q "Comm: dnsmasq Tainted:"; then logger "dnsmasq tainted detected, restarting dnsmasq"; service restart_dnsmasq; fi
+tail -F "$tailfile" | while read -r line
+do
+	if echo "$line" | grep -q "Comm: dnsmasq Tainted:"
+	then
+	    logger "dnsmasq tainted detected, restarting dnsmasq"
+	    service restart_dnsmasq
+	fi
 done
 
 renice 0 $$
+
+#EOF#

--- a/tailtaintdnsd
+++ b/tailtaintdnsd
@@ -1,13 +1,23 @@
 #!/bin/sh
+######################################################
+# Last Modified: 2026-Apr-11
+#-----------------------------------------------------
 # shellcheck disable=SC2039
 # shellcheck disable=SC3048
+#-----------------------------------------------------
+
 trap '' SIGHUP
+
+# Give priority to built-in binaries #
+export PATH="/bin:/usr/bin:/sbin:/usr/sbin:$PATH"
 
 /jffs/addons/scmerlin.d/tailtaintdns &
 
-while true; do
+while true
+do
 	sleep 5
-	if [ "$(pidof tailtaintdns | wc -w)" -lt 1 ]; then
+	if [ "$(pidof tailtaintdns | wc -w)" -lt 1 ]
+	then
 		logger "tailtaintdns dead, restarting..."
 		killall -q tailtaintdns
 		sleep 5
@@ -15,3 +25,5 @@ while true; do
 		logger "tailtaintdns restarted"
 	fi
 done
+
+#EOF#

--- a/tailtop
+++ b/tailtop
@@ -1,8 +1,24 @@
 #!/bin/sh
+######################################################
+# Last Modified: 2026-Apr-11
+#-----------------------------------------------------
 # shellcheck disable=SC2039
+#-----------------------------------------------------
+
 trap '' SIGHUP
 renice 15 $$
-while true; do
+
+# Give priority to built-in binaries #
+export PATH="/bin:/usr/bin:/sbin:/usr/sbin:$PATH"
+
+if [ $# -eq 0 ] || [ -z "$1" ] || \
+   ! echo "$1" | grep -qE "^([1-9][0-9]{0,2})$"
+then sleepSecs=60
+else sleepSecs="$1"
+fi
+
+while true
+do
 	top -b -n 1 | tail -n +5 | head -n -1 | sed 's/S </S</g;s/S N/SN/g;s/S D/SD/g;s/R N/RN/g;' | \
 awk -F" " -v OFS=',' '{if ($5 ~ /m[^\s\\]/){
 printf "%s,%s,%s,%s,%s,%s,%s,", $1,$2,$3,$4,gensub(/m([^\s\\])/,"m,\\1","g",$5),$6,$7;for(i=8; i<=NF; ++i) printf "%s ", $i; print ""
@@ -12,6 +28,9 @@ printf "%s,%s,%s,%s,%s,%s,%s,%s,", $1,$2,$3,$4,$5,$6,$7,$8;for(i=9; i<=NF; ++i) 
 }
 }' | \
 sed 's/,$//g;s/S</S </g;s/SN/S N/g;s/SD/S D/g;s/RN/R N/g;' > /tmp/scmerlin-top
-	sleep 4
+	sleep "$sleepSecs"
 done
+
 renice 0 $$
+
+#EOF#

--- a/tailtopd
+++ b/tailtopd
@@ -1,16 +1,29 @@
 #!/bin/sh
+######################################################
+# Last Modified: 2026-Apr-11
+#-----------------------------------------------------
 # shellcheck disable=SC2039
+#-----------------------------------------------------
+
 trap '' SIGHUP
 
-/jffs/addons/scmerlin.d/tailtop &
+# Give priority to built-in binaries #
+export PATH="/bin:/usr/bin:/sbin:/usr/sbin:$PATH"
 
-while true; do
-	sleep 5
-	if [ "$(pidof tailtop | wc -w)" -lt 1 ]; then
+sleepSecs=120  #2 minutes#
+/jffs/addons/scmerlin.d/tailtop "$sleepSecs" &
+
+while true
+do
+	sleep 30
+	if [ "$(pidof tailtop | wc -w)" -lt 1 ]
+	then
 		logger -t scMerlin "tailtop dead, restarting..."
 		killall -q tailtop
 		sleep 5
-		/jffs/addons/scmerlin.d/tailtop &
+		/jffs/addons/scmerlin.d/tailtop "$sleepSecs" &
 		logger -t scMerlin "tailtop restarted"
 	fi
 done
+
+#EOF#


### PR DESCRIPTION
- Added "`unset LD_LIBRARY_PATH`" line as a workaround due to the latest Entware binaries using the **RUNPATH** embedded library search path mechanism instead of the previous **RPATH** method. **RUNPATH** is searched **AFTER** the LD_LIBRARY_PATH definitions, whereas **RPATH** has higher priority than the LD_LIBRARY_PATH environment variable, so it's searched **FIRST**.

- Miscellaneous improvements.
